### PR TITLE
Add conflict

### DIFF
--- a/ark-town/mod.json
+++ b/ark-town/mod.json
@@ -6,6 +6,7 @@
 	"version": "1.0.3",
 	"modType": "Town", 
 	"depends" : [ "hota.cove", "hota.interference" ],
+	"conflicts" : [ "an-expansion.skills.warfare" ],
 	"compatibility": {
 		"min": "1.6.0"
 	},


### PR DESCRIPTION
Due to Warfare submod of an-expansion blocking the ballistics skill, it breaks the Ark-town, so added it to conflicts.